### PR TITLE
Fix grouped field buttons z-index based on presence of border

### DIFF
--- a/sass/form/tools.sass
+++ b/sass/form/tools.sass
@@ -7,6 +7,8 @@ $help-size: $size-small !default
 
 $label-colors: $form-colors !default
 
+$button-borderless-colors: ('white','light','black','text','primary','link','info','succes','warning','danger') !default
+
 .label
   color: $label-color
   display: block
@@ -71,17 +73,22 @@ $label-colors: $form-colors !default
       .button,
       .input,
       .select select
+        z-index: 2
         &:not([disabled])
           &:hover,
           &.is-hovered
-            z-index: 2
+            z-index: 3
           &:focus,
           &.is-focused,
           &:active,
           &.is-active
-            z-index: 3
+            z-index: 4
             &:hover
-              z-index: 4
+              z-index: 5
+      .button
+        @each $name, $pair in $button-borderless-colors
+          &.is-#{$name}
+            z-index: 1
       &.is-expanded
         flex-grow: 1
         flex-shrink: 1


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a **new feature | improvement | bugfix | documentation fix**.
<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
